### PR TITLE
Add build step to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ To install dependencies locally, execute:
 make install
 ```
 
+Before running, you need to build the Docker container `libero/storybook:dev` locally:
+```shell
+make build
+```
+
 To run Storybook, execute:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ To install dependencies locally, execute:
 make install
 ```
 
-Before running, you need to build the Docker container `libero/storybook:dev` locally:
+To build the Storybook container:
+
 ```shell
 make build
 ```


### PR DESCRIPTION
Works after initial build, first-time clone and run resulted in:
```
Unable to find image 'libero/storybook:dev' locally
docker: Error response from daemon: pull access denied for libero/storybook, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```