### PR TITLE
Reduce size of Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
-node_modules
+/.docker/
+/.github/
+/.scripts/
+/build/
+/Makefile
+/node_modules/


### PR DESCRIPTION
Reduces the size, and speeds up building the container. Tested with the image, still builds and runs the `npm install` step without issue.

<details>
<summary>
Before
</summary>
<pre><code>▶ make build
docker build --target dev --tag libero/storybook:dev .
Sending build context to Docker daemon  140.9MB
Step 1/14 : FROM node:10.16.3-alpine AS node
</pre></code>
</details>


<details>
<summary>
After
</summary>
<pre><code>▶ make build
docker build --target dev --tag libero/storybook:dev .
Sending build context to Docker daemon  1.008MB
Step 1/14 : FROM node:10.16.3-alpine AS node
</pre></code>
</details>
