### PR TITLE
Fix Travis builds by using Bash as the shell in Make

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-/.docker/
 /.github/
 /.scripts/
 /build/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .DEFAULT_GOAL = help
 
+SHELL = /usr/bin/env bash
 REAL_ENV = $$(if [[ $${ENV} = "prod" ]]; then echo "prod"; else echo "dev"; fi)
 NAME = storybook-${REAL_ENV}
 TAG = libero/storybook:${REAL_ENV}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Requirements
 ------------
 
 - [Docker](https://www.docker.com/)
+- [GNU Bash](https://www.gnu.org/software/bash/)
 - [GNU Make](https://www.gnu.org/software/make/)
 - [Node.js](https://nodejs.org/) (for development)
 


### PR DESCRIPTION
Travis builds currently use `sh` as the shell, but the Makefile requires Bash. Rather than remove Bash-isms, this makes it required.

(Discovered by the collision after a failure in https://travis-ci.com/libero/storybook/builds/131471907. Turns out Travis was not building `prod` instances, always falling back to `dev`.)