### PR TITLE
Simplify border mixin

### DIFF
--- a/src/shared-styles/_decoration.scss
+++ b/src/shared-styles/_decoration.scss
@@ -3,16 +3,6 @@
 @use "grid";
 @use "logical";
 
-@mixin border($dimension: null) {
-
-  @if index((inline, inline-start, inline-end, block, block-start, block-end), $dimension) {
-    @include logical.property(border, $dimension, (grid.$divider-size solid color.$text-dividers,), $to-rem: false);
-  } @else if $dimension == null {
-    border: grid.$divider-size solid color.$text-dividers;
-  } @else if index((top, bottom, left, right), $dimension) {
-    @include error.throw("'#{$dimension}' is a physical dimension, use its logical equivilant");
-  } @else {
-    @include error.throw("Unknown dimension '#{$dimension}'");
-  }
-
+@mixin border($dimension: all) {
+  @include logical.property(border, $dimension, (grid.$divider-size solid color.$text-dividers,), $to-rem: false);
 }

--- a/src/shared-styles/_logical.scss
+++ b/src/shared-styles/_logical.scss
@@ -274,7 +274,7 @@
     }
 
   } @else if index((top, bottom, left, right, width, height), $dimension) {
-    @include error.throw("'#{$dimension}' is a physical dimension, use its logical equivilant");
+    @include error.throw("'#{$dimension}' is a physical dimension, use its logical equivalent");
   } @else {
     @include error.throw("Unknown dimension '#{$dimension}'");
   }

--- a/src/shared-styles/_logical.scss
+++ b/src/shared-styles/_logical.scss
@@ -177,7 +177,7 @@
 
     @if length($property-name) > 1 {
       @include error.throw("Expected a single property name");
-    } @else if not index(inset margin padding, $property-name) {
+    } @else if not index(inset margin padding border, $property-name) {
       @include error.throw("Can't combine block and inline for '#{$property-name}'");
     } @else {
 

--- a/src/shared-styles/_space.scss
+++ b/src/shared-styles/_space.scss
@@ -106,7 +106,7 @@
     }
 
   } @else if index((top, bottom, left, right), $dimension) {
-    @include error.throw("'#{$dimension}' is a physical dimension, use its logical equivilant");
+    @include error.throw("'#{$dimension}' is a physical dimension, use its logical equivalent");
   } @else {
     @include error.throw("Unknown dimension '#{$dimension}'");
   }

--- a/test/sass/decoration.spec.scss
+++ b/test/sass/decoration.spec.scss
@@ -150,7 +150,7 @@
       }
 
       @include contains {
-        _error: "'top' is a physical dimension, use its logical equivilant";
+        _error: "'top' is a physical dimension, use its logical equivalent";
       }
 
     }

--- a/test/sass/logical.spec.scss
+++ b/test/sass/logical.spec.scss
@@ -930,7 +930,7 @@
       }
 
       @include contains {
-        _error: "'top' is a physical dimension, use its logical equivilant";
+        _error: "'top' is a physical dimension, use its logical equivalent";
       }
 
     }

--- a/test/sass/logical.spec.scss
+++ b/test/sass/logical.spec.scss
@@ -954,11 +954,11 @@
     @include assert() {
 
       @include output {
-        @include logical.property(float, all, left);
+        @include logical.property(margin-inline, all, 16px);
       }
 
       @include expect {
-        _error: "Can't combine block and inline for 'float'";
+        _error: "Can't combine block and inline for 'margin-inline'";
       }
 
     }

--- a/test/sass/logical.spec.scss
+++ b/test/sass/logical.spec.scss
@@ -954,11 +954,11 @@
     @include assert() {
 
       @include output {
-        @include logical.property(border, all, 16px);
+        @include logical.property(float, all, left);
       }
 
       @include expect {
-        _error: "Can't combine block and inline for 'border'";
+        _error: "Can't combine block and inline for 'float'";
       }
 
     }

--- a/test/sass/space.spec.scss
+++ b/test/sass/space.spec.scss
@@ -1498,7 +1498,7 @@ $_baseline-unit: scale.$base * 0.375;
       }
 
       @include expect {
-        _error: "'top' is a physical dimension, use its logical equivilant";
+        _error: "'top' is a physical dimension, use its logical equivalent";
       }
 
     }
@@ -3011,7 +3011,7 @@ $_baseline-unit: scale.$base * 0.375;
       }
 
       @include expect {
-        _error: "'top' is a physical dimension, use its logical equivilant";
+        _error: "'top' is a physical dimension, use its logical equivalent";
       }
 
     }
@@ -3260,7 +3260,7 @@ $_baseline-unit: scale.$base * 0.375;
       }
 
       @include contains {
-        _error: "'top' is a physical dimension, use its logical equivilant";
+        _error: "'top' is a physical dimension, use its logical equivalent";
       }
 
     }


### PR DESCRIPTION
Remove duplication of the `border()` mixin doing its own check for physical properties. `border()` mixin is now a thin wrapper around `logical.property()`.

Also, spelling.