### PR TITLE
Allow Storybook iframe <HTML>'s lang and dir to be settable by pattern

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -33,5 +33,5 @@ addParameters({
 
 addDecorator(centered);
 addDecorator(withA11y);
-
+addParameters({ dir: 'ltr', lang: 'en' });
 configure(context, module);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -33,4 +33,5 @@ addParameters({
 
 addDecorator(centered);
 addDecorator(withA11y);
+
 configure(context, module);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -33,5 +33,4 @@ addParameters({
 
 addDecorator(centered);
 addDecorator(withA11y);
-addParameters({ dir: 'ltr', lang: 'en' });
 configure(context, module);

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,7 +6,7 @@
      * it doesn't have a value, or the value is empty.
      *
      * @param {string} htmlAttributeName
-     * @return {string} - The value found to set as htmlAttributeName
+     * @return {string} - The value found to set for htmlAttributeName
      */
     const findValue = function(htmlAttributeName) {
 

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -55,13 +55,8 @@
     },
   ];
 
-  // The event listener is flaky. Backed up with a 3s timeout if nothing's fired by then.
-  const timeout = window.setTimeout(function () {
+   window.setTimeout(function () {
     updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
   }, 3000);
 
-  // window.self.addEventListener('load', function() {
-  //   window.clearTimeout(timeout);
-  //   updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
-  // });
 </script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -9,28 +9,28 @@
    * name of the desired attribute. If it finds it, it returns the value of that data attribute, or an empty string if
    * it does not have a value, or the value is empty.
    *
-   * @param {string} attribute
-   * @return {string} The value found to set for the attribute
+   * @param {string} htmlAttributeName
+   * @return {string} - The value found to set as htmlAttributeName
    */
-  const findValue = (attribute) => {
+  const findValue = (htmlAttributeName) => {
 
     const strWithInitialCapital = (str) => {
       return `${str.charAt(0).toUpperCase()}${str.substring(1)}`;
     };
 
-    const attributeSource = document.querySelector(`[data-storybook-htmlattr-${attribute}]`);
+    const attributeSource = document.querySelector(`[data-storybook-htmlattr-${htmlAttributeName}]`);
     if (attributeSource) {
-      return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(attribute)}`] || '';
+      return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(htmlAttributeName)}`] || '';
     }
     return '';
   };
 
   /**
-   * Iterates over a list of attributes to update on the <html> element, and updates them if they're permitted to be,
-   * either with the found value, or a default value if supplied.
+   * Iterates over a list of attributes to update on the <html> element, and if allowed updates them: either with the
+   * found value, or a default value if supplied.
    *
-   * @param {Array} toUpdate The attributes to set on <html>
-   * @param {Array} allowed The attributes permitted to be set, and an optional default value for each
+   * @param {Array} toUpdate - The attributes to set on <html>
+   * @param {Array} allowed - The attributes permitted to be set, and an optional default value for each
    */
   const updateHtmlAttributes = function(toUpdate, allowed) {
     allowed.forEach(function(allowedAttribute) {
@@ -55,6 +55,7 @@
     },
   ];
 
+  // Listening for an event doesn't work
    window.setTimeout(function () {
     updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
   }, 3000);

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,63 +1,64 @@
 <script>
-  // TODO: Move Purpose & Motivation to README & expand upon it once nearly finalised
-  // Purpose: to allow specification of attributes for the <html> element of the iframe that loads a story
-  // Motivation: CSS selectors handling logical property rules depend on <html dir="[value]"...> but Storybook doesn't
-  //  allow easy configuration of these.
+  (function() {
+    // TODO: Move Purpose & Motivation to README & expand upon it once nearly finalised
+    // Purpose: to allow specification of attributes for the <html> element of the iframe that loads a story
+    // Motivation: CSS selectors handling logical property rules depend on <html dir="[value]"...> but Storybook doesn't
+    //  allow easy configuration of these.
 
-  /**
-   * Searches for an element with a data attribute prefixed with "data-storybook-htmlattr-", and ending in the
-   * name of the desired attribute. If it finds it, it returns the value of that data attribute, or an empty string if
-   * it does not have a value, or the value is empty.
-   *
-   * @param {string} htmlAttributeName
-   * @return {string} - The value found to set as htmlAttributeName
-   */
-  const findValue = (htmlAttributeName) => {
+    /**
+     * Searches for an element with a data attribute prefixed with "data-storybook-htmlattr-", and ending in the
+     * name of the desired attribute. If it finds it, it returns the value of that data attribute, or an empty string if
+     * it does not have a value, or the value is empty.
+     *
+     * @param {string} htmlAttributeName
+     * @return {string} - The value found to set as htmlAttributeName
+     */
+    const findValue = (htmlAttributeName) => {
 
-    const strWithInitialCapital = (str) => {
-      return `${str.charAt(0).toUpperCase()}${str.substring(1)}`;
+      const strWithInitialCapital = (str) => {
+        return `${str.charAt(0).toUpperCase()}${str.substring(1)}`;
+      };
+
+      const attributeSource = document.querySelector(`[data-storybook-htmlattr-${htmlAttributeName}]`);
+      if (attributeSource) {
+        return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(htmlAttributeName)}`] || '';
+      }
+      return '';
     };
 
-    const attributeSource = document.querySelector(`[data-storybook-htmlattr-${htmlAttributeName}]`);
-    if (attributeSource) {
-      return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(htmlAttributeName)}`] || '';
-    }
-    return '';
-  };
-
-  /**
-   * Iterates over a list of attributes to update on the <html> element, and if allowed updates them: either with the
-   * found value, or a default value if supplied.
-   *
-   * @param {Array} toUpdate - The attributes to set on <html>
-   * @param {Array} allowed - The attributes permitted to be set, and an optional default value for each
-   */
-  const updateHtmlAttributes = function(toUpdate, allowed) {
-    allowed.forEach(function(allowedAttribute) {
-      const allowedName = allowedAttribute.name;
-      if (toUpdate.indexOf(allowedName) > -1) {
-        const value = findValue(allowedName) || allowedAttribute.defaultValue;
-        if (value && value.length) {
-          document.querySelector('html').setAttribute(allowedName, value);
+    /**
+     * Iterates over a list of attributes to update on the <html> element, and if allowed updates them: either with the
+     * found value, or a default value if supplied.
+     *
+     * @param {Array} toUpdate - The attributes to set on <html>
+     * @param {Array} allowed - The attributes permitted to be set, and an optional default value for each
+     */
+    const updateHtmlAttributes = function(toUpdate, allowed) {
+      allowed.forEach(function(allowedAttribute) {
+        const allowedName = allowedAttribute.name;
+        if (toUpdate.indexOf(allowedName) > -1) {
+          const value = findValue(allowedName) || allowedAttribute.defaultValue;
+          if (value && value.length) {
+            document.querySelector('html').setAttribute(allowedName, value);
+          }
         }
-      }
-    });
-  };
+      });
+    };
 
-  const allowedAttributes = [
-    {
-      name: 'lang',
-      defaultValue: 'en',
-    },
-    {
-      name: 'dir',
-      defaultValue: 'ltr',
-    },
-  ];
+    const allowedAttributes = [
+      {
+        name: 'lang',
+        defaultValue: 'en',
+      },
+      {
+        name: 'dir',
+        defaultValue: 'ltr',
+      },
+    ];
 
-  // Listening for an event doesn't work
-   window.setTimeout(function () {
-    updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
-  }, 3000);
-
+    // Listening for an event doesn't work
+     window.setTimeout(function () {
+      updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
+    }, 3000);
+  }());
 </script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,23 +1,38 @@
 <script>
-  // TODO: Document
-  const getIntendedAttributeValue = (attribute) => {
+  const findValue = (attribute) => {
+
     const strWithInitialCapital = (str) => {
-      const initialCapital = str.charAt(0).toUpperCase();
-      return `${initialCapital}${str.substring(1)}`;
+      return `${str.charAt(0).toUpperCase()}${str.substring(1)}`;
     };
 
-    const allowed = ['dir', 'lang'];
-    if (allowed.indexOf(attribute) > -1) {
-      const target = document.querySelector(`[data-storybook-only-${attribute}]`);
-      return target.dataset[`storybookOnly${strWithInitialCapital(attribute)}`];
+    const attributeSource = document.querySelector(`[data-storybook-htmlattr-${attribute}]`);
+    if (attributeSource) {
+      return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(attribute)}`];
     }
     return '';
   };
 
-  const updateHtmlAttributes = () => {
-    const attributeNames = ['dir', 'lang'];
-    attributeNames.forEach((name) => document.querySelector('html').setAttribute(name, getIntendedAttributeValue(name)));
+  const updateHtmlAttributes = function(toUpdate, allowed) {
+    allowed.forEach(function(allowedAttribute) {
+      if (toUpdate === allowedAttribute) {
+        const value = findValue(allowedAttribute.name) || allowedAttribute.defaultValue;
+        if (value && value.length) {
+          document.querySelector('html').setAttribute(allowedAttribute, value);
+        }
+      }
+    });
   };
 
-  window.setTimeout(updateHtmlAttributes, 3000);
+  const allowedAttributes = [
+    {
+      name: 'lang',
+      defaultValue: 'en',
+    },
+    {
+      name: 'dir',
+      defaultValue: 'ltr',
+    },
+  ];
+
+  window.self.addEventListener('load', function() { updateHtmlAttributes(['dir', 'lang'], allowedAttributes); });
 </script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -34,10 +34,11 @@
    */
   const updateHtmlAttributes = function(toUpdate, allowed) {
     allowed.forEach(function(allowedAttribute) {
-      if (toUpdate === allowedAttribute) {
-        const value = findValue(allowedAttribute.name) || allowedAttribute.defaultValue;
+      const allowedName = allowedAttribute.name;
+      if (toUpdate.indexOf(allowedName) > -1) {
+        const value = findValue(allowedName) || allowedAttribute.defaultValue;
         if (value && value.length) {
-          document.querySelector('html').setAttribute(allowedAttribute, value);
+          document.querySelector('html').setAttribute(allowedName, value);
         }
       }
     });
@@ -59,8 +60,8 @@
     updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
   }, 3000);
 
-  window.self.addEventListener('load', function() {
-    window.clearTimeout(timeout);
-    updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
-  });
+  // window.self.addEventListener('load', function() {
+  //   window.clearTimeout(timeout);
+  //   updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
+  // });
 </script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -13,9 +13,9 @@
      * @param {string} htmlAttributeName
      * @return {string} - The value found to set as htmlAttributeName
      */
-    const findValue = (htmlAttributeName) => {
+    const findValue = function(htmlAttributeName) {
 
-      const strWithInitialCapital = (str) => {
+      const strWithInitialCapital = function(str) {
         return `${str.charAt(0).toUpperCase()}${str.substring(1)}`;
       };
 

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -11,12 +11,12 @@
     const findValue = function(htmlAttributeName) {
 
       const strWithInitialCapital = function(str) {
-        return `${str.charAt(0).toUpperCase()}${str.substring(1)}`;
+        return str.charAt(0).toUpperCase() + str.substring(1);
       };
 
-      const attributeSource = document.querySelector(`[data-storybook-htmlattr-${htmlAttributeName}]`);
+      const attributeSource = document.querySelector('[data-storybook-htmlattr-' + htmlAttributeName + ']');
       if (attributeSource) {
-        return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(htmlAttributeName)}`] || '';
+        return attributeSource.dataset['storybookHtmlattr' + strWithInitialCapital(htmlAttributeName)] || '';
       }
       return '';
     };

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,17 @@
 <script>
+  // TODO: Move Purpose & Motivation to README & expand upon it once nearly finalised
+  // Purpose: to allow specification of attributes for the <html> element of the iframe that loads a story
+  // Motivation: CSS selectors handling logical property rules depend on <html dir="[value]"...> but Storybook doesn't
+  //  allow easy configuration of these.
+
+  /**
+   * Searches for an element with a data attribute prefixed with "data-storybook-htmlattr-", and ending in the
+   * name of the desired attribute. If it finds it, it returns the value of that data attribute, or an empty string if
+   * it does not have a value, or the value is empty.
+   *
+   * @param {string} attribute
+   * @return {string} The value found to set for the attribute
+   */
   const findValue = (attribute) => {
 
     const strWithInitialCapital = (str) => {
@@ -12,6 +25,13 @@
     return '';
   };
 
+  /**
+   * Iterates over a list of attributes to update on the <html> element, and updates them if they're permitted to be,
+   * either with the found value, or a default value if supplied.
+   *
+   * @param {Array} toUpdate The attributes to set on <html>
+   * @param {Array} allowed The attributes permitted to be set, and an optional default value for each
+   */
   const updateHtmlAttributes = function(toUpdate, allowed) {
     allowed.forEach(function(allowedAttribute) {
       if (toUpdate === allowedAttribute) {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,33 @@
 <script>
-  document.querySelector('html').setAttribute('dir', 'rtl');
+  const getIntendedDir = () => {
+    return _getIntended('dir');
+  };
+
+  const getIntendedLang = () => {
+    return _getIntended('lang');
+  };
+
+  const _getIntended = (attribute) => {
+    const strWithInitialCapital = (str) => {
+      const initialCapital = str.charAt(0).toUpperCase();
+      return `${initialCapital}${str.substring(1)}`;
+    };
+
+    const allowed = ['dir', 'lang'];
+    if (allowed.indexOf(attribute) > -1) {
+      const target = document.querySelector(`[data-storybook-only-${attribute}]`);
+      return target.dataset[`storybookOnly${strWithInitialCapital(attribute)}`];
+    }
+    return '';
+  };
+
+  const updateHtmlAttrs = () => {
+    const dir = getIntendedDir();
+    document.querySelector('html').setAttribute('dir', dir);
+
+    const lang = getIntendedLang();
+    document.querySelector('html').setAttribute('lang', lang);
+  };
+
+  window.setTimeout(updateHtmlAttrs, 3000);
 </script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,3 @@
+<script>
+  document.querySelector('html').setAttribute('dir', 'rtl');
+</script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -7,7 +7,7 @@
 
     const attributeSource = document.querySelector(`[data-storybook-htmlattr-${attribute}]`);
     if (attributeSource) {
-      return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(attribute)}`];
+      return attributeSource.dataset[`storybookHtmlattr${strWithInitialCapital(attribute)}`] || '';
     }
     return '';
   };

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -34,5 +34,13 @@
     },
   ];
 
-  window.self.addEventListener('load', function() { updateHtmlAttributes(['dir', 'lang'], allowedAttributes); });
+  // The event listener is flaky. Backed up with a 3s timeout if nothing's fired by then.
+  const timeout = window.setTimeout(function () {
+    updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
+  }, 3000);
+
+  window.self.addEventListener('load', function() {
+    window.clearTimeout(timeout);
+    updateHtmlAttributes(['dir', 'lang'], allowedAttributes);
+  });
 </script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,14 +1,9 @@
 <script>
   (function() {
-    // TODO: Move Purpose & Motivation to README & expand upon it once nearly finalised
-    // Purpose: to allow specification of attributes for the <html> element of the iframe that loads a story
-    // Motivation: CSS selectors handling logical property rules depend on <html dir="[value]"...> but Storybook doesn't
-    //  allow easy configuration of these.
-
-    /**
+   /**
      * Searches for an element with a data attribute prefixed with "data-storybook-htmlattr-", and ending in the
-     * name of the desired attribute. If it finds it, it returns the value of that data attribute, or an empty string if
-     * it does not have a value, or the value is empty.
+     * name of the desired attribute. If it finds the data attribute, it returns its value, or an empty string if
+     * it doesn't have a value, or the value is empty.
      *
      * @param {string} htmlAttributeName
      * @return {string} - The value found to set as htmlAttributeName

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,13 +1,6 @@
 <script>
-  const getIntendedDir = () => {
-    return _getIntended('dir');
-  };
-
-  const getIntendedLang = () => {
-    return _getIntended('lang');
-  };
-
-  const _getIntended = (attribute) => {
+  // TODO: Document
+  const getIntendedAttributeValue = (attribute) => {
     const strWithInitialCapital = (str) => {
       const initialCapital = str.charAt(0).toUpperCase();
       return `${initialCapital}${str.substring(1)}`;
@@ -21,13 +14,10 @@
     return '';
   };
 
-  const updateHtmlAttrs = () => {
-    const dir = getIntendedDir();
-    document.querySelector('html').setAttribute('dir', dir);
-
-    const lang = getIntendedLang();
-    document.querySelector('html').setAttribute('lang', lang);
+  const updateHtmlAttributes = () => {
+    const attributeNames = ['dir', 'lang'];
+    attributeNames.forEach((name) => document.querySelector('html').setAttribute(name, getIntendedAttributeValue(name)));
   };
 
-  window.setTimeout(updateHtmlAttrs, 3000);
+  window.setTimeout(updateHtmlAttributes, 3000);
 </script>

--- a/README.md
+++ b/README.md
@@ -49,14 +49,16 @@ To lint the JavaScript (report and fix), execute:
 make fix
 ```
 
-## Grid system
+## Sass
 
-### Concept
+### Grid system
+
+#### Concept
 The grid comprises a full-viewport-width grid within which is a central section of 12<sup>*</sup> equal-sized columns. The central 12 columns are collectively known as the `main` part of the grid, which holds the content of the page. The full width of the grid from viewport edge to viewport edge is known as the `full` width grid. The `full` width grid exists in order to allow items of content to give the impression of breaking out of the (`main` part of the) grid. It should also make it easier to implement [subgrids](https://www.w3.org/TR/css-grid-2/#subgrids) when they get browser support.
 
 <sup>*</sup>12 is the default number of columns, but this can be configured. See "Configuring the grid" below. 
 
-### Implementation
+#### Implementation
 
 All grids are in `src/patterns/grids/`.  
 
@@ -64,30 +66,30 @@ The grid is implemented using CSS grid. Non-supporting browsers will display a s
 
 Page templates implementing this grid system should use the page grid template. `page-grid.twig` sets up the rows of the top level explicit grid, and handles loading of the lower order grids that directly control content layout with respect to the grid columns (e.g. the content grid `content-grid.twig`).  
 
-In order to preserve the capabilities of seeming to break out of the grid, and of attempting to be future-friendly to sub grids, every lower order grid (i.e. below the level of `page-grid`) must span the `full` width of the grid, and, in addition to anything else the template does, supply css classes to allow its items to span the `full` or `main` width of the grid. For example the `content-grid` provides the css classes `content-grid__item--full` and `content-grid__item--main` respectively.
+[In order to preserve the capabilities of seeming to break out of the grid, and of attempting to be future-friendly to sub grids, every lower order grid (i.e. below the level of `page-grid`) must span the `full` width of the grid, and, in addition to anything else the template does, supply css classes to allow its items to span the `full` or `main` width of the grid. For example the `content-grid` provides the css classes `content-grid__item--full` and `content-grid__item--main` respectively.
 
 All nested levels of grid must conform to this `main` / `full` model in order to retain the benefits of this approach.
 
-#### Grid templates
+##### Grid templates
 
-##### `page-grid`
+###### `page-grid`
 The top level page grid. It sets up the rows of the top level explicit grid as named areas `start`, `main` and `end`. Typically `start` and `end` would be used to hold the site header and site footer respectively, with everything else located in the `main` row. This is the template to include directly in implementations. Lower level grids, into which the page content actually loads, should be included by `page-grid`.
 
-###### grid areas recommended usage
+####### grid areas recommended usage
 - `start`: put the site header here
 - `main`: put everything between the site header and footer here       
 - `end`: put the site footer here
 
-##### `content-grid`
+###### `content-grid`
 The grid for all content pages (i.e. not listing pages). In addition to the capability to specify if content spans the entirety of the `main` or `full` sections, this grid defines areas called `primary`, `secondary`, and `menu`. These names are used for both the CSS grid area names and the twig template section names. This grid lays out content with a very similar layout to that of an eLife article.
 
-###### grid areas recommended usage
+####### grid areas recommended usage
 - `primary`: the content that makes this page what it is
 - `secondary`: supplementary info, typically used for asides       
 - `menu`: a menu / navigation appropriate to the content level
    
 
-#### Configuring the grid
+##### Configuring the grid
 The grid may be configured using the following Sass variables defined in `/src/shared-styles/_grid.scss`:
 
 - `$max-inline-size` the max width of the `main` grid section in pixels (default: `1114px`)
@@ -95,8 +97,6 @@ The grid may be configured using the following Sass variables defined in `/src/s
 - `$column-gap` the width between grid columns, also the minimum inline start / end page gutter when CSS grid is not supported by the browser; may be expressed in any css length unit (default: `1.6%`)  
 - `$edge-space-medium`: a medium sized inline start / end page gutter (default: `7vw`), usage controlled by a breakpoint
 - `$edge-space-wide`: a large inline start / end page gutter (default: `14vw`), usage controlled by a breakpoint
-
-## Sass
 
 ### A note on logical property fallbacks
 Fallbacks for [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) are implemented for horizontal writing directions (see [`_logical.scss`](https://github.com/libero/storybook/blob/master/src/shared-styles/_logical.scss)). At the moment they require the following treatment of HTML `dir` attributes:
@@ -121,7 +121,27 @@ Fallbacks for [logical properties](https://developer.mozilla.org/en-US/docs/Web/
 
 </div>
 
+```                   
+
+#### Setting `<html>` attributes in Storybook
+Storybook loads its stories into an iframe within the main UI. It's possible to set attributes on the `<html>` element of the iframe, this is required for setting logical properties correctly.
+
+To set `dir` on `<html>`, pass `'data-storybook-htmlattr-dir': '[value]'` in the `attributes` property passed to the pattern template. By default `<html dir="ltr"...>` will be set by default if a value isn't configured.    
+
+To set `lang` on `<html>`, pass `'data-storybook-htmlattr-lang': '[value]'` in the `attributes` property passed to the pattern template.
+
+By default `<html lang="en"...>` will be set by default if a value isn't configured.
+
+For example, to set `<html lang="ar" lang="rtl"...>`, pass
 ```
+    attributes:
+      {
+        'data-storybook-htmlattr-dir': 'rtl',
+        'data-storybook-htmlattr-lang': 'ar',
+        ...
+      },
+```     
+
 Getting help
 ------------
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The grid is implemented using CSS grid. Non-supporting browsers will display a s
 
 Page templates implementing this grid system should use the page grid template. `page-grid.twig` sets up the rows of the top level explicit grid, and handles loading of the lower order grids that directly control content layout with respect to the grid columns (e.g. the content grid `content-grid.twig`).  
 
-[In order to preserve the capabilities of seeming to break out of the grid, and of attempting to be future-friendly to sub grids, every lower order grid (i.e. below the level of `page-grid`) must span the `full` width of the grid, and, in addition to anything else the template does, supply css classes to allow its items to span the `full` or `main` width of the grid. For example the `content-grid` provides the css classes `content-grid__item--full` and `content-grid__item--main` respectively.
+In order to preserve the capabilities of seeming to break out of the grid, and of attempting to be future-friendly to sub grids, every lower order grid (i.e. below the level of `page-grid`) must span the `full` width of the grid, and, in addition to anything else the template does, supply css classes to allow its items to span the `full` or `main` width of the grid. For example the `content-grid` provides the css classes `content-grid__item--full` and `content-grid__item--main` respectively.
 
 All nested levels of grid must conform to this `main` / `full` model in order to retain the benefits of this approach.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ For example, to set `<html lang="ar" lang="rtl"...>`, pass
         'data-storybook-htmlattr-lang': 'ar',
         ...
       },
-```     
+```
+
+Note that regular `dir` and `lang` attributes can still be set on the pattern itself.     
 
 Getting help
 ------------

--- a/src/patterns/molecules/error/error.stories.js
+++ b/src/patterns/molecules/error/error.stories.js
@@ -47,8 +47,8 @@ export const ErrorAr = () => error(
   {
     attributes:
       {
-        dir: 'rtl',
-        lang: 'ar',
+        'data-storybook-only-dir': 'rtl',
+        'data-storybook-only-lang': 'ar',
       },
     image:
       {

--- a/src/patterns/molecules/error/error.stories.js
+++ b/src/patterns/molecules/error/error.stories.js
@@ -47,8 +47,8 @@ export const ErrorAr = () => error(
   {
     attributes:
       {
-        'data-storybook-only-dir': 'rtl',
-        'data-storybook-only-lang': 'ar',
+        'data-storybook-htmlattr-dir': 'rtl',
+        'data-storybook-htmlattr-lang': 'ar',
       },
     image:
       {


### PR DESCRIPTION
## Description
This PR addresses the problem that Storybook doesn't add a `dir` attribute to the `<html>` element. This attribute is [relied upon by the CSS](https://github.com/libero/storybook/blob/master/src/shared-styles/_direction.scss) for e.g. setting logical property rules and fallbacks.

The approach uses Storybook's [custom head tags](https://storybook.js.org/docs/configurations/add-custom-head-tags/) to inject a script into the iframe that loads the story. It interrogates the DOM for data attributes specifying the values that should be set for `dir` and `lang` attributes on the iframe's `<html>` element. If these aren't found then default values `lang="en" dir="ltr"` are set.

It's been built in a way that makes it easy to add more attributes if required.

Note that it's triggered by a(n arbitrary) 3 second timeout, which is a bit hacky. The iframe's `load` event is fired before the story's DOM is available, closing off that route, unfortunately.

## Usage
To override the default `dir` and / or `lang` attributes on the story-loading-iframe's `<html>` element, add one or both of the following attributes to the story definition:
```
attributes: {
  'data-storybook-htmlattr-dir': 'rtl',  // overrides default 'ltr' 
  'data-storybook-htmlattr-lang': 'ar', // overrides default 'en'
  ...
},
```
